### PR TITLE
Improvements to NestedMapping

### DIFF
--- a/astar_utils/nested_mapping.py
+++ b/astar_utils/nested_mapping.py
@@ -41,6 +41,9 @@ class NestedMapping(MutableMapping):
             to_pop = []
             for key in new_dict:
                 if key.startswith("!"):
+                    logging.warning(
+                        "Using bang-strings in KEYS is deprecated and will no "
+                        "longer work in future releases: %s", key)
                     self[key] = new_dict[key]
                     to_pop.append(key)
             for key in to_pop:

--- a/astar_utils/nested_mapping.py
+++ b/astar_utils/nested_mapping.py
@@ -140,9 +140,8 @@ class NestedMapping(MutableMapping):
     def _write_subdict(self, subdict: Mapping, stream: TextIO,
                        pad: str = "") -> None:
         pre = pad.replace("├─", "│ ").replace("└─", "  ")
-        n_sub = len(subdict)
         for i_sub, (key, val) in enumerate(subdict.items()):
-            subpre = "└─" if i_sub == n_sub - 1 else "├─"
+            subpre = "└─" if i_sub == len(subdict) - 1 else "├─"
             stream.write(f"{pre}{subpre}{key}: ")
             if isinstance(val, Mapping):
                 self._write_subdict(val, stream, pre + subpre)

--- a/astar_utils/nested_mapping.py
+++ b/astar_utils/nested_mapping.py
@@ -181,8 +181,7 @@ class NestedMapping(MutableMapping):
 
     def write_string(self, stream: TextIO) -> None:
         """Write formatted string representation to I/O stream."""
-        name = self._title or self.__class__.__name__
-        stream.write(f"{name} contents:")
+        stream.write(f"{self.title} contents:")
         self._write_subdict(self.dic, stream, "\n")
 
     def __repr__(self) -> str:
@@ -195,6 +194,11 @@ class NestedMapping(MutableMapping):
             self.write_string(str_stream)
             output = str_stream.getvalue()
         return output
+
+    @property
+    def title(self) -> str:
+        """Return title if set, or default to class name."""
+        return self._title or self.__class__.__name__
 
 
 def recursive_update(old_dict: MutableMapping, new_dict: Mapping) -> MutableMapping:

--- a/astar_utils/nested_mapping.py
+++ b/astar_utils/nested_mapping.py
@@ -13,8 +13,9 @@ class NestedMapping(MutableMapping):
     # TODO: improve docstring
     """Dictionary-like structure that supports nested !-bang string keys."""
 
-    def __init__(self, new_dict: Iterable = None):
+    def __init__(self, new_dict: Iterable = None, title: str = None):
         self.dic = {}
+        self._title = title
         if isinstance(new_dict, MutableMapping):
             self.update(new_dict)
         elif isinstance(new_dict, Iterable):
@@ -150,7 +151,8 @@ class NestedMapping(MutableMapping):
 
     def write_string(self, stream: TextIO) -> None:
         """Write formatted string representation to I/O stream."""
-        stream.write(f"{self.__class__.__name__} contents:")
+        name = self._title or self.__class__.__name__
+        stream.write(f"{name} contents:")
         self._write_subdict(self.dic, stream, "\n")
 
     def __repr__(self) -> str:

--- a/astar_utils/nested_mapping.py
+++ b/astar_utils/nested_mapping.py
@@ -120,7 +120,7 @@ class NestedMapping(MutableMapping):
                 "re-assign a new sub-mapping to the key.")
 
     def _staggered_items(self, key: str, value: Mapping):
-        # TODO: py39: -> Iterator[]
+        # TODO: py39: -> Iterator[tuple[str, Any]]
         simple = []
         for subkey, subvalue in value.items():
             new_key = self._join_subkey(key, subkey)
@@ -150,6 +150,7 @@ class NestedMapping(MutableMapping):
                         stream: TextIO, nested: bool = False):
         # TODO: py39: items: Iterable[tuple[str, Any]]
         # TODO: py39: -> list[tuple[str, Any]]
+        # TODO: could this (and _write_subdict) use _staggered_items instead??
         n_items = len(items)
         simple = []
 

--- a/tests/test_nested_mapping.py
+++ b/tests/test_nested_mapping.py
@@ -166,9 +166,9 @@ class TestFunctionRecursiveUpdate:
 
 class TestRepresentation:
     def test_str_conversion(self, nested_nestmap):
-        desired = ("NestedMapping contents:\n├─foo: 5\n├─bar: \n│ ├─bogus: "
-                   "\n│ │ ├─a: 42\n│ │ └─b: 69\n│ └─baz: meh\n├─moo: "
-                   "yolo\n└─yeet: \n  ├─x: 0\n  └─y: 420")
+        desired = ("NestedMapping contents:\n├─bar: \n│ ├─bogus: \n│ │ ├─a: "
+                   "42\n│ │ └─b: 69\n│ └─baz: meh\n├─yeet: \n│ ├─x: 0\n│ └─y: "
+                   "420\n├─foo: 5\n└─moo: yolo")
         assert str(nested_nestmap) == desired
 
     def test_repr_conversion(self, nested_nestmap):
@@ -181,6 +181,6 @@ class TestRepresentation:
         assert len(nested_nestmap) == 7
 
     def test_list_returns_keys(self, nested_nestmap):
-        desired = ["foo", "!bar.bogus.a", "!bar.bogus.b", "!bar.baz", "moo",
-                   "!yeet.x", "!yeet.y"]
+        desired = ["!bar.bogus.a", "!bar.bogus.b", "!bar.baz", "!yeet.x",
+                   "!yeet.y", "foo", "moo"]
         assert list(nested_nestmap) == desired

--- a/tests/test_nested_mapping.py
+++ b/tests/test_nested_mapping.py
@@ -172,9 +172,19 @@ class TestFunctionRecursiveUpdate:
 
 class TestRepresentation:
     def test_str_conversion(self, nested_nestmap):
-        desired = ("NestedMapping contents:\n├─bar: \n│ ├─bogus: \n│ │ ├─a: "
-                   "42\n│ │ └─b: 69\n│ └─baz: meh\n├─yeet: \n│ ├─x: 0\n│ └─y: "
-                   "420\n├─foo: 5\n└─moo: yolo")
+        desired = """
+NestedMapping contents:
+├─bar: 
+│ ├─bogus: 
+│ │ ├─a: 42
+│ │ └─b: 69
+│ └─baz: meh
+├─yeet: 
+│ ├─x: 0
+│ └─y: 420
+├─foo: 5
+└─moo: yolo
+""".strip()
         assert str(nested_nestmap) == desired
 
     def test_repr_conversion(self, nested_nestmap):

--- a/tests/test_nested_mapping.py
+++ b/tests/test_nested_mapping.py
@@ -38,7 +38,9 @@ def nested_nestmap(nested_dict):
 
 class TestInit:
     def test_initialises_with_nothing(self):
-        assert isinstance(NestedMapping(), NestedMapping)
+        nestmap = NestedMapping()
+        assert isinstance(nestmap, NestedMapping)
+        assert nestmap.title == "NestedMapping"
 
     def test_initalises_with_normal_dict(self):
         nestmap = NestedMapping({"a": 1, "b": 2})
@@ -55,6 +57,10 @@ class TestInit:
     def test_initalises_with_nested_dict(self, nested_nestmap):
         assert isinstance(nested_nestmap, NestedMapping)
         assert "moo" in nested_nestmap.dic
+
+    def test_init_with_title(self, basic_yaml):
+        nestmap = NestedMapping(basic_yaml, title="MyNestMap")
+        assert nestmap.title == "MyNestMap"
 
 
 class TestActsLikeDict:
@@ -184,3 +190,7 @@ class TestRepresentation:
         desired = ["!bar.bogus.a", "!bar.bogus.b", "!bar.baz", "!yeet.x",
                    "!yeet.y", "foo", "moo"]
         assert list(nested_nestmap) == desired
+
+    def test_title_is_in_str(self, basic_yaml):
+        nestmap = NestedMapping(basic_yaml, title="MyNestMap")
+        assert "MyNestMap" in str(nestmap)


### PR DESCRIPTION
- Printing and iterating over `NestedMapping` now considers nested keys first for each sub-level of nesting, similar to what is commonly seen in tree-like structures. This also applies to `NestedMapping.keys()`.
- `NestedMapping` now accepts an optional argument `title`, which becomes a property and is included in the string representation. If not set, this will default to the class name.
- A warning is logged if a bang-string is found in a _key_. The resulting behavior is unchanged.
This should resolve #4 for now.