### PR TITLE
Properly implement version bump workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -69,7 +69,9 @@ jobs:
         if: github.event.inputs.dry-run == 'true'
         env:
           BUMP_MSG: ${{ steps.bumping.outputs.BUMP_MSG }}
-        run: echo "$BUMP_MSG"
+        run: |
+          echo "## $BUMP_MSG" >> $GITHUB_STEP_SUMMARY
+          echo "Dry run only, no actual modification made." >> $GITHUB_STEP_SUMMARY
 
       - name: Commit changes
         # could also use https://github.com/stefanzweifel/git-auto-commit-action instead
@@ -81,3 +83,5 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -am "$BUMP_MSG"
           git push
+          echo "## $BUMP_MSG" >> $GITHUB_STEP_SUMMARY
+          echo "Successfully committed and pushed version bump." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -61,12 +61,12 @@ jobs:
       - name: Bump package Version using Poetry
         id: bumping
         env:
-          RULE: ${{ github.event.inputs.rule }}
-          DRY: ${{ github.event.inputs.dry-run == 'true' && '--dry-run' || '' }}
+          RULE: ${{ inputs.rule }}
+          DRY: ${{ inputs.dry-run && '--dry-run' || '' }}
         run: echo "BUMP_MSG=$(poetry version $DRY $RULE)" >> $GITHUB_OUTPUT
 
       - name: Output debug msg
-        if: github.event.inputs.dry-run == 'true'
+        if: inputs.dry-run
         env:
           BUMP_MSG: ${{ steps.bumping.outputs.BUMP_MSG }}
         run: |
@@ -75,7 +75,7 @@ jobs:
 
       - name: Commit changes
         # could also use https://github.com/stefanzweifel/git-auto-commit-action instead
-        if: github.event.inputs.dry-run == 'false'
+        if: ${{ ! inputs.dry-run }}
         env:
           BUMP_MSG: ${{ steps.bumping.outputs.BUMP_MSG }}
         run: |

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -19,6 +19,9 @@ jobs:
   bump:
     name: Bump version number
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -37,9 +40,19 @@ jobs:
         id: bumping
         env:
           RULE: ${{ github.event.inputs.rule }}
-        run: echo "MSG=$(poetry version --dry-run $RULE)" >> $GITHUB_OUTPUT
+        run: echo "BUMP_MSG=$(poetry version $RULE)" >> $GITHUB_OUTPUT
 
       - name: Output debug msg
         env:
-          BMPMSG: ${{ steps.bumping.outputs.MSG }}
-        run: echo "$BMPMSG"
+          BUMP_MSG: ${{ steps.bumping.outputs.BUMP_MSG }}
+        run: echo "$BUMP_MSG"
+
+      - name: Commit changes
+        # could also use https://github.com/stefanzweifel/git-auto-commit-action instead
+        env:
+          BUMP_MSG: ${{ steps.bumping.outputs.BUMP_MSG }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "$BUMP_MSG"
+          git push

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -44,16 +44,18 @@ jobs:
         id: bumping
         env:
           RULE: ${{ github.event.inputs.rule }}
-          DRY: ${{ github.event.inputs.dry-run == 'true' && '--dry-run' }}
+          DRY: ${{ github.event.inputs.dry-run == 'true' && '--dry-run' || '' }}
         run: echo "BUMP_MSG=$(poetry version $DRY $RULE)" >> $GITHUB_OUTPUT
 
       - name: Output debug msg
+        if: github.event.inputs.dry-run == 'true'
         env:
           BUMP_MSG: ${{ steps.bumping.outputs.BUMP_MSG }}
         run: echo "$BUMP_MSG"
 
       - name: Commit changes
         # could also use https://github.com/stefanzweifel/git-auto-commit-action instead
+        if: github.event.inputs.dry-run == 'false'
         env:
           BUMP_MSG: ${{ steps.bumping.outputs.BUMP_MSG }}
         run: |

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -5,6 +5,7 @@ on:
       dry-run:
         type: boolean
         description: Only output new version number, no actual change.
+        required: false
       rule:
         type: choice
         description: Version bump level
@@ -19,12 +20,29 @@ on:
         - prerelease
         - "prerelease --next-phase"
 
+  workflow_call:
+    inputs:
+      dry-run:
+        type: boolean
+        description: Only output new version number, no actual change.
+        required: false
+      rule:
+        type: string
+        description: Version bump level
+        required: true
+    outputs:
+      bumpmsg:
+        description: Message created by the version bump.
+        value: ${{ jobs.bump.outputs.bumpmsg }}
+
 jobs:
   bump:
     name: Bump version number
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      bumpmsg: ${{ steps.bumping.outputs.BUMP_MSG }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -36,8 +36,10 @@ jobs:
       - name: Store current Version
         id: current-version
         run: |
+          echo "$(poetry version)"
+          echo poetry version
           echo "CURRENT_VERSION=$(poetry version --short)" >> $GITHUB_OUTPUT
 
       - name: Bump package Version using Poetry
-        run: echo steps.current-version.outputs.CURRENT_VERSION
+        run: echo "${{ steps.current-version.outputs.CURRENT_VERSION }}"
         # run: poetry version ${{ github.event.inputs.rule }}

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -33,13 +33,13 @@ jobs:
         with:
           poetry-version: "1.7.0"
 
-      - name: Store current Version
-        id: current-version
-        run: |
-          echo "$(poetry version)"
-          echo poetry version
-          echo "CURRENT_VERSION=$(poetry version --short)" >> $GITHUB_OUTPUT
-
       - name: Bump package Version using Poetry
-        run: echo "${{ steps.current-version.outputs.CURRENT_VERSION }}"
-        # run: poetry version ${{ github.event.inputs.rule }}
+        id: bumping
+        env:
+          RULE: ${{ github.event.inputs.rule }}
+        run: echo "MSG=$(poetry version --dry-run $RULE)" >> $GITHUB_OUTPUT
+
+      - name: Output debug msg
+        env:
+          BMPMSG: ${{ steps.bumping.outputs.MSG }}
+        run: echo "$BMPMSG"

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -2,9 +2,13 @@ name: Bump package version
 on:
   workflow_dispatch:
     inputs:
+      dry-run:
+        type: boolean
+        description: Only output new version number, no actual change.
       rule:
         type: choice
         description: Version bump level
+        required: true
         options:
         - major
         - minor
@@ -40,7 +44,8 @@ jobs:
         id: bumping
         env:
           RULE: ${{ github.event.inputs.rule }}
-        run: echo "BUMP_MSG=$(poetry version $RULE)" >> $GITHUB_OUTPUT
+          DRY: ${{ github.event.inputs.dry-run == 'true' && '--dry-run' }}
+        run: echo "BUMP_MSG=$(poetry version $DRY $RULE)" >> $GITHUB_OUTPUT
 
       - name: Output debug msg
         env:


### PR DESCRIPTION
This is a continuation of #14, to fully implement the version bumper GitHub actions workflow.

The workflow can be manually trigger or requested by another workflow and takes one required parameter (the bump rule, or level) and also has an option to perform a dry run, not actually making any modifications. If run without the dry-run option (the normal default), the workflow will commit and push the modifications to the branch it was run from. The commit is officially done by the GitHub Actions Bot. This has the advantage that we don't need a PR to e.g. increment to the next dev version after a release. In the future, this might actually become part of the release workflow, to make sure we're immediately back to a dev version afterwards.

As with the release workflow, this will ultimately become part of the DevOps repo, once it has been proven here.