### PR TITLE
Improve `pyproject.toml` file and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,20 @@
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
-This package is devloped and maintained by [Astar Vienna](https://github.com/AstarVienna) and contains commonly-used utilities for the group's projects.
+This package is devloped and maintained by [Astar Vienna](https://github.com/AstarVienna) and contains commonly-used utilities for the group's projects to avoid both duplicating code and circular dependencies.
+
+## Contents
+
+The package currently contains the following public functions and classes:
+
+- `NestedMapping`: a `dict`-like structure supporting !-style nested keys.
+- `UniqueList`: a `list`-like structure with no duplicate elements and some convenient methods.
+
+## Dependencies
+
+Dependencies are intentionally kept to a minimum for simplicity. Current dependencies are:
+
+- `more-itertools`
+- `pyyaml`
+
+Version requirement for these dependencies can be found in the `pyproject.toml` file.

--- a/astar_utils/__init__.py
+++ b/astar_utils/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from .nested_mapping import NestedMapping
+from .unique_list import UniqueList

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,21 @@
 [tool.poetry]
 name = "astar-utils"
 version = "0.1.2a0"
-description = ""
+description = "Contains commonly-used utilities for AstarVienna's projects."
+license = "GPL-3.0-or-later"
 authors = ["Fabian Haberhauer <fabian.haberhauer@univie.ac.at>"]
+maintainers = [
+    "Fabian Haberhauer <fabian.haberhauer@univie.ac.at>",
+    "Hugo Buddelmeijer <hugo@buddelmeijer.nl>",
+]
 readme = "README.md"
+repository = "https://github.com/AstarVienna/astar-utils"
+classifiers = [
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Topic :: Scientific/Engineering :: Astronomy",
+    "Topic :: Utilities"
+]
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
- Populate the `pyproject.toml` file with some more fields.
- Expand the README a bit.
- Enable imports like `from astar_utils import NestedMapping`, instead of having to do `from astar_utils.nested_mapping import NestedMapping` for convenience.