### PR TITLE
Use new DevOps tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,5 +13,11 @@ on:
 
 jobs:
   call-tests:
-    name: Call tests
+    name: Offline tests
     uses: AstarVienna/DevOps/.github/workflows/tests.yml@poetry
+    secrets: inherit
+
+  call-updated-tests:
+    name: Tests with updated dependencies
+    uses: AstarVienna/DevOps/.github/workflows/updated_tests.yml@poetry
+    secrets: inherit


### PR DESCRIPTION
This repo does not use the `webtest` marker anywhere, but the updated dependencies test is certainly useful to include.