### PR TITLE
Fix case when init or update NestedMapping with another NestedMapping

### DIFF
--- a/astar_utils/nested_mapping.py
+++ b/astar_utils/nested_mapping.py
@@ -28,7 +28,7 @@ class NestedMapping(MutableMapping):
                 self.update(entry)
 
     def update(self, new_dict: MutableMapping[str, Any]) -> None:
-        if isinstance(new_dict, self.__class__):
+        if isinstance(new_dict, NestedMapping):
             new_dict = new_dict.dic  # Avoid updating with another one
 
         # TODO: why do we check for dict here but not in the else?

--- a/astar_utils/nested_mapping.py
+++ b/astar_utils/nested_mapping.py
@@ -28,6 +28,9 @@ class NestedMapping(MutableMapping):
                 self.update(entry)
 
     def update(self, new_dict: MutableMapping[str, Any]) -> None:
+        if isinstance(new_dict, self.__class__):
+            new_dict = new_dict.dic  # Avoid updating with another one
+
         # TODO: why do we check for dict here but not in the else?
         if isinstance(new_dict, Mapping) \
                 and "alias" in new_dict \

--- a/astar_utils/nested_mapping.py
+++ b/astar_utils/nested_mapping.py
@@ -49,9 +49,9 @@ class NestedMapping(MutableMapping):
             to_pop = []
             for key in new_dict:
                 if key.startswith("!"):
-                    logger.warning(
-                        "Using bang-strings in KEYS is deprecated and will no "
-                        "longer work in future releases: %s", key)
+                    logger.debug(
+                        "Bang-string key %s was seen in .update. This should "
+                        "not occur outside mocking in testing!", key)
                     self[key] = new_dict[key]
                     to_pop.append(key)
             for key in to_pop:


### PR DESCRIPTION
This caused weird warnings in ScopeSim, because the update method would get the bang-keys from the NestedMapping instance used to init another one. What we probably really want in that case anyway is to init (or update) it with the internal nested dict of the NestedMapping. This should fix those warnings.

Edit: Apparently this is still triggered in mocks (patch dict) within testing (I think the mock patch used `.update()` with all keys to restore the original dict). So downgrading to DEBUG and changing wording, because this is then normal, but still shouldn't happen outside mocking.