### PR TITLE
Allow for empty "properties" subdict

### DIFF
--- a/astar_utils/nested_mapping.py
+++ b/astar_utils/nested_mapping.py
@@ -32,15 +32,13 @@ class NestedMapping(MutableMapping):
             new_dict = new_dict.dic  # Avoid updating with another one
 
         # TODO: why do we check for dict here but not in the else?
-        if isinstance(new_dict, Mapping) \
-                and "alias" in new_dict \
-                and "properties" in new_dict:
+        if isinstance(new_dict, Mapping) and "alias" in new_dict:
             alias = new_dict["alias"]
+            propdict = new_dict.get("properties", {})
             if alias in self.dic:
-                self.dic[alias] = recursive_update(self.dic[alias],
-                                                   new_dict["properties"])
+                self.dic[alias] = recursive_update(self.dic[alias], propdict)
             else:
-                self.dic[alias] = new_dict["properties"]
+                self.dic[alias] = propdict
         elif isinstance(new_dict, Sequence):
             # To catch list of tuples
             self.update(dict([new_dict]))


### PR DESCRIPTION
Fixes a long-ignored bug where some keys could "get lost" in the `__currsys__` if an "alias" but no "properties" is present in a yaml dict. This occurs e.g. in MICADO's `default.yaml` in the SCAO and MCAO modes, that don't (and probably don't need to) define any "properties". But then `NestedMapping.update()` defaults to simply updating key-value-wise.

### Devil's Advocaat

The alternative would be to introduce an empty "properties" in each of the yamls. But then people will forget that somewhere and we're back at the bug, so that's fragile. Also would probably require an update to multiple IRDB packages, which is annoying.

### Rant

I'm generally not a fan of this "abusive" overloading of the `.update()` method. I think that method should only do what you'd expect from a standard dict (in fact, by inheriting from `collections.abc.MutableMapping`, we wouldn't even need to define such a "standard" `.update()` method here...). The "special sauce" that's added here is also rather ScopeSim-specific and thus shouldn't really be in `astar-utils` to begin with. Perhaps an extra method (`.update_alias()`??) would be fine though. Same thing actually goes for `UserCommands.update()` over in ScopeSim, although I started to mitigate that in the (as of writing this un-PR'd) `fh/chainmap` branch...
