### PR TITLE
Add more bang-string-key functionality

### DIFF
--- a/astar_utils/__init__.py
+++ b/astar_utils/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from .nested_mapping import NestedMapping
+from .nested_mapping import (NestedMapping, RecursiveNestedMapping,
+                             NestedChainMap, is_bangkey, is_nested_mapping)
 from .unique_list import UniqueList
 from .badges import Badge, BadgeReport
 from .loggers import get_logger, get_astar_logger

--- a/astar_utils/nested_mapping.py
+++ b/astar_utils/nested_mapping.py
@@ -72,6 +72,9 @@ class NestedMapping(MutableMapping):
                 entry = entry[chunk]
             except KeyError as err:
                 raise KeyError(key) from err
+
+        if is_nested_mapping(entry):
+            return self.__class__(entry)
         return entry
 
     def __setitem__(self, key: str, value) -> None:
@@ -209,6 +212,13 @@ class NestedMapping(MutableMapping):
 def is_bangkey(key) -> bool:
     """Return ``True`` if the key is a ``str`` and starts with a "!"."""
     return isinstance(key, str) and key.startswith("!")
+
+
+def is_nested_mapping(mapping) -> bool:
+    """Return ``True`` if `mapping` contains any further map as a value."""
+    if not isinstance(mapping, Mapping):
+        return False
+    return any(isinstance(value, Mapping) for value in mapping.values())
 
 
 def recursive_update(old_dict: MutableMapping, new_dict: Mapping) -> MutableMapping:

--- a/astar_utils/nested_mapping.py
+++ b/astar_utils/nested_mapping.py
@@ -209,6 +209,17 @@ class NestedMapping(MutableMapping):
         return self._title or self.__class__.__name__
 
 
+class RecursiveNestedMapping(NestedMapping):
+    """Like NestedMapping but internally resolves any bang-string values."""
+
+    def __getitem__(self, key: str):
+        """x.__getitem__(y) <==> x[y]."""
+        value = super().__getitem__(key)
+        while is_bangkey(value):
+            value = self[value]
+        return value
+
+
 def is_bangkey(key) -> bool:
     """Return ``True`` if the key is a ``str`` and starts with a "!"."""
     return isinstance(key, str) and key.startswith("!")

--- a/tests/test_nested_mapping.py
+++ b/tests/test_nested_mapping.py
@@ -286,9 +286,20 @@ class TestNestedChainMap:
         simple_nestchainmap._repr_pretty_(printer, False)
         printer.text.assert_called_with(str(simple_nestchainmap))
 
-    def test_subdict_key_in_multiple_levels(self, simple_nestchainmap):
+
+class TestNestedChainMapSubdictKeyInMultipleLevels:
+    def test_returns_chainmap_if_found_in_multiple(self, simple_nestchainmap):
         assert isinstance(simple_nestchainmap["foo"], NestedChainMap)
+
+    def test_subdict_chainmap_has_correct_len(self, simple_nestchainmap):
         assert len(simple_nestchainmap["foo"]) == 3
+
+    def test_returns_nestmap_if_found_in_only_one(self):
+        ncm = NestedChainMap(
+            RecursiveNestedMapping({"foo": {"a": "!foo.b"}}),
+            RecursiveNestedMapping({"bar": {"b": "bogus", "c": "baz"}})
+        )
+        assert isinstance(ncm["foo"], RecursiveNestedMapping)
 
 
 @pytest.mark.parametrize(("key", "result"),

--- a/tests/test_nested_mapping.py
+++ b/tests/test_nested_mapping.py
@@ -44,7 +44,7 @@ def nested_nestmap(nested_dict):
 def simple_nestchainmap():
     ncm = NestedChainMap(
         RecursiveNestedMapping({"foo": {"a": "!foo.b"}}),
-        RecursiveNestedMapping({"foo": {"b": "bogus"}})
+        RecursiveNestedMapping({"foo": {"b": "bogus", "c": "baz"}})
     )
     return ncm
 
@@ -285,6 +285,10 @@ class TestNestedChainMap:
         printer.text.assert_called_with("NestedChainMap(...)")
         simple_nestchainmap._repr_pretty_(printer, False)
         printer.text.assert_called_with(str(simple_nestchainmap))
+
+    def test_subdict_key_in_multiple_levels(self, simple_nestchainmap):
+        assert isinstance(simple_nestchainmap["foo"], NestedChainMap)
+        assert len(simple_nestchainmap["foo"]) == 3
 
 
 @pytest.mark.parametrize(("key", "result"),


### PR DESCRIPTION
# Modifications

## `NestedMapping`

- Modify `.__getitem__()` to return another instance of `NestedMapping` (or any subclass), if the about-to-be-returned value is another nested `dict`. This effectively enables the further use of the bang-string-key syntax on extracted sub-dicts.
- Minimal refactoring also to `.__setitem__()` and `.__delitem__()`, without any functional changes.
- Addition of a `_repr_pretty_()` method for nice output in an IPython console.

## Other

We were now importing so many classes from `collections.abc`, and also now `ChainMap` directly from `collections`, that I decided to just do `from collections import abc, ChainMap` and add the `abc.` to all those base classes here. No functional changes here.

# New classes and functions

## `RecursiveNestedMapping`

A subclass of the existing `NestedMapping`, this simply modifies the `.__getitem__(key)` method such that if a returned value is itself a valid bang-string, it will be used to (recursively) look up the value associated with it. If that bang-string is not a key in the mapping, it will be returned as-is, i.e. as an unresolved bang-string. In the case of a "chain" of bang-strings each pointing to the next one (e.g. `"!FOO.bar": "!FOO.baz"` ➡️ `"!FOO.baz": "!BAR.foo"` ➡️ `"!BAR.foo": 42`), that chain will be recursively resolved until either a non-bang-string value (either a `str` without a leading `"!"` or not a `str` at all) is found, or a bang-string that is not a valid key in the mapping, in which case the final, unresolved string will be returned.

Additionally, an alternative constructor is provided in the `.from_maps(maps, key)` class method. This is useful for, and currently only used by, the `NestedChainMap` (see below), yielding numbered instances for each map in `maps` that contains the specified `key`.

### "But @teutoburg!", I hear you yell, "What about infinite recursion??"

Fear not! In the case that someone was silly enough to create a "loop" of bang-string keys pointing back to the first one (e.g. `"!FOO.bar": "!FOO.baz"` ➡️ `"!FOO.baz": "!BAR.foo"` ➡️ `"!BAR.foo": "!FOO.bar"` ➡️ `"!FOO.bar": "!FOO.baz"` ➡️ ♾️), Python's builtin recursion limit will kick in virtually instantly and yeet a standard `RecursionError`.

## `NestedChainMap`

A subclass of `collections.ChainMap` using using `RecursiveNestedMapping`. It only overrides the `.__getitem__(key)` method to allow for both recursive bang-string-keys pointing across the individual mappings and to "collect" sub-mappings from the same bang-key in multiple mappings into a new `NestedChainMap`. Also overrides `.__str__()` and provides a `._repr_pretty_()` for nice output to an IPython console.

In the absence of any nested mappings or bang-string-keys, this will work like the base class `collections.ChainMap`, meaning an ordinary `dict` can also be used as one of the individual mapping "levels". For the dreaded case of infinite loops of bang-string-keys pointing to each other, the behavior is identical to this case in a `RecursiveNestedMapping`, also across multiple mappings.

## `is_bangkey(key)`

Convenience function, return `True` if `key` is a) a `str` and b) starts with a `"!"`, `False` otherwise. Intended as a shorthand to avoid having to spell out the `isinstance` and `.startswith` all the time...

## `is_nested_mapping(mapping)`

Convenience function, return `True` if a) `mapping` is Mapping and b) at least one value in `mapping` is itself another Mapping, `False` otherwise. Used to determine if it makes sense to wrap `mapping` in a `NestedMapping`.

# Rejected alternatives

## Building the recursive function into the existing `NestedMapping` class

While easier, the recursive functionality is only needed in some cases (e.g. ScopeSim) and not in others (e.g. SpeXtra). It is, IMO, clearly a distinct functionality from just providing a short-hand syntax for accessing nested dicts, like `NestedMapping` does, so should be kept separately. 

## Putting either or both of the new classes in ScopeSim

While currently only used in ScopeSim, it would somewhat defeat the purpose of outsourcing things here to do that. At least for the `RecursiveNestedMapping`, which directly builds on `NestedMapping`. And since `NestedChainMap` also used `RecursiveNestedMapping` internally, I think it makes most sense to keep both classes here. This might have the added benefit of maybe reusing them somewhere else in the future.

## `RecursiveNestedChainMap` / `NestedRecursiveChainMap` / `RecursiveChainMap`

YAGNI, at least for now...

# Maybe in the future...

- I'm currently also in the process of shuffling the "alias-properties" functionality over to ScopeSim's responsibility, so once that's done and tested, I'll remove it here in another PR (or probably have it still working but add a `DepcrecationWarning`).
- Add a way to retrieve a recursive bang-string in a value from a `RecursiveNestedMapping`. The default will now be to always (attempt to) resolve such cases, but there might be situations where it is required to extract "where it's pointing to", rather than the final resulting value. Currently, the only way to do this is to access the internal mapping via the old `.dic` attribute. Although the string representation (and also the `__repr__` for that matter) _do_ return everything UNresolved, so inspection is already possible that way.
- Since the module now contains more than just `NestedMapping` and a helper function, I'm considering renaming it to something like `bang_maps`. Other (less innuendo-prone) suggestions are welcome...