### PR TITLE
Allow unresolved values in `NestedChainMap`

### DIFF
--- a/astar_utils/nested_mapping.py
+++ b/astar_utils/nested_mapping.py
@@ -273,9 +273,13 @@ class NestedChainMap(ChainMap):
                 return submaps[0]
             return NestedChainMap(*submaps)
 
-        if is_bangkey(value):
-            value = self[value]
+        while is_bangkey(value):
+            try:
+                value = self[value]
+            except KeyError:
+                return value
         return value
+
 
     def __str__(self):
         """Return str(self)."""

--- a/tests/test_nested_mapping.py
+++ b/tests/test_nested_mapping.py
@@ -279,6 +279,13 @@ class TestNestedChainMap:
         with pytest.raises(RecursionError):
             ncm["!foo.a"]
 
+    def test_returns_unresolved_as_is(self):
+        ncm = NestedChainMap(
+            RecursiveNestedMapping({"foo": {"a": "!foo.b"}}),
+            RecursiveNestedMapping({"foo": {"b": "!foo.c"}})
+        )
+        assert ncm["!foo.a"] == "!foo.c"
+
     def test_repr_pretty(self, simple_nestchainmap):
         printer = Mock()
         simple_nestchainmap._repr_pretty_(printer, True)


### PR DESCRIPTION
This already works in a single `RecursiveNestedMapping`, but the `NestedChainMap` will still throw an error if a recursive bang-string-key ends up pointing to a "dead end", i.e. another, unresolved, bang key.

Maybe we'd want to include a "strict mode" for this, so we can enable that for some applications in ScopeSim, where we actually want an error in such a case. Something similar is currently done in some places, i.e. check if something is still a bang key when it should be a float or whatever. So by having a "strict mode" for resolving recursive bang keys, we wouldn't need that because the `NestedChainMap` would just throw a `KeyError`. Kinda like it currently does. Hmm, this again makes me wonder if we actually _want_ this change, or if all errors from unresolved bang keys in ScopeSim are maybe really a symptom of something else being wrong. Yeah, I'll keep this a draft for now...