### PR TITLE
Add resolving string to `NestedChainMap`

### DIFF
--- a/astar_utils/nested_mapping.py
+++ b/astar_utils/nested_mapping.py
@@ -276,7 +276,7 @@ class NestedChainMap(ChainMap):
 
     def __getitem__(self, key):
         """x.__getitem__(y) <==> x[y]."""
-        value = super().__getitem__(key)
+        value = super().__getitem__(key.removesuffix("!"))
 
         if isinstance(value, abc.Mapping):
             submaps = tuple(RecursiveNestedMapping.from_maps(self.maps, key))
@@ -285,7 +285,7 @@ class NestedChainMap(ChainMap):
                 return submaps[0]
             return NestedChainMap(*submaps)
 
-        if is_bangkey(value):
+        if is_bangkey(value) and is_resolving_key(key):
             value = self[value]
         return value
 
@@ -304,6 +304,11 @@ class NestedChainMap(ChainMap):
 def is_bangkey(key) -> bool:
     """Return ``True`` if the key is a ``str`` and starts with a "!"."""
     return isinstance(key, str) and key.startswith("!")
+
+
+def is_resolving_key(key) -> bool:
+    """Return ``True`` if the key is a ``str`` and ends with a "!"."""
+    return isinstance(key, str) and key.endswith("!")
 
 
 def is_nested_mapping(mapping) -> bool:

--- a/astar_utils/nested_mapping.py
+++ b/astar_utils/nested_mapping.py
@@ -237,12 +237,14 @@ class RecursiveNestedMapping(NestedMapping):
 
     def __getitem__(self, key: str):
         """x.__getitem__(y) <==> x[y]."""
-        value = super().__getitem__(key)
-        while is_bangkey(value):
+        value = super().__getitem__(key.removesuffix("!"))
+
+        if is_bangkey(value) and is_resolving_key(key):
             try:
-                value = self[value]
+                value = self[f"{value}!"]
             except KeyError:
-                return value
+                pass  # return value unresolved
+
         return value
 
     @classmethod

--- a/astar_utils/nested_mapping.py
+++ b/astar_utils/nested_mapping.py
@@ -286,7 +286,11 @@ class NestedChainMap(ChainMap):
             return NestedChainMap(*submaps)
 
         if is_bangkey(value) and is_resolving_key(key):
-            value = self[value]
+            try:
+                value = self[f"{value}!"]
+            except KeyError:
+                pass  # return value unresolved
+
         return value
 
     def __str__(self):

--- a/tests/test_nested_mapping.py
+++ b/tests/test_nested_mapping.py
@@ -268,16 +268,18 @@ class TestRecursiveNestedMapping:
 
 
 class TestNestedChainMap:
-    def test_resolves_bangs(self, simple_nestchainmap):
-        assert simple_nestchainmap["!foo.a"] == "bogus"
+    @pytest.mark.parametrize(("key", "result"), (("!foo.a", "!foo.b"),
+                                                 ("!foo.a!", "bogus")))
+    def test_resolves_bangs(self, simple_nestchainmap, key, result):
+        assert simple_nestchainmap[key] == result
 
     def test_infinite_loop(self):
         ncm = NestedChainMap(
-            RecursiveNestedMapping({"foo": {"a": "!foo.b"}}),
-            RecursiveNestedMapping({"foo": {"b": "!foo.a"}})
+            RecursiveNestedMapping({"foo": {"a": "!foo.b!"}}),
+            RecursiveNestedMapping({"foo": {"b": "!foo.a!"}})
         )
         with pytest.raises(RecursionError):
-            ncm["!foo.a"]
+            ncm["!foo.a!"]
 
     def test_repr_pretty(self, simple_nestchainmap):
         printer = Mock()

--- a/tests/test_nested_mapping.py
+++ b/tests/test_nested_mapping.py
@@ -230,7 +230,15 @@ NestedMapping contents:
 
 
 class TestRecursiveNestedMapping:
-    def test_resolves_bangs(self):
+    @pytest.mark.parametrize(("key", "result"), (("bar", "!foo"),
+                                                 ("bar!", "a")))
+    def test_resolves_bangs(self, key, result):
+        rnm = RecursiveNestedMapping({"foo": "a", "bar": "!foo"})
+        assert rnm[key] == result
+
+    @pytest.mark.parametrize(("key", "result"), (("!foo.b", "!bar.y"),
+                                                 ("!foo.b!", 42)))
+    def test_resolves_bangs_multistage(self, key, result):
         rnm = RecursiveNestedMapping(
             {"foo": {
                 "a": "!bar.x",
@@ -241,7 +249,7 @@ class TestRecursiveNestedMapping:
                  "y": "!foo.a",
               },
              })
-        assert rnm["!foo.b"] == 42
+        assert rnm[key] == result
 
     def test_infinite_loop(self):
         rnm = RecursiveNestedMapping(
@@ -255,7 +263,7 @@ class TestRecursiveNestedMapping:
               },
              })
         with pytest.raises(RecursionError):
-            rnm["!foo.b"]
+            rnm["!foo.b!"]
 
     def test_returns_unresolved_as_is(self):
         rnm = RecursiveNestedMapping(
@@ -264,7 +272,7 @@ class TestRecursiveNestedMapping:
                 "b": "!bar.y",
               },
              })
-        assert rnm["!foo.b"] == "!bar.y"
+        assert rnm["!foo.b!"] == "!bar.y"
 
 
 class TestNestedChainMap:

--- a/tests/test_nested_mapping.py
+++ b/tests/test_nested_mapping.py
@@ -273,10 +273,17 @@ class TestNestedChainMap:
     def test_resolves_bangs(self, simple_nestchainmap, key, result):
         assert simple_nestchainmap[key] == result
 
+    def test_returns_unresolved_as_is(self):
+        ncm = NestedChainMap(
+            RecursiveNestedMapping({"foo": {"a": "!foo.b"}}),
+            RecursiveNestedMapping({"foo": {"b": "!foo.c"}})
+        )
+        assert ncm["!foo.a!"] == "!foo.c"
+
     def test_infinite_loop(self):
         ncm = NestedChainMap(
-            RecursiveNestedMapping({"foo": {"a": "!foo.b!"}}),
-            RecursiveNestedMapping({"foo": {"b": "!foo.a!"}})
+            RecursiveNestedMapping({"foo": {"a": "!foo.b"}}),
+            RecursiveNestedMapping({"foo": {"b": "!foo.a"}})
         )
         with pytest.raises(RecursionError):
             ncm["!foo.a!"]


### PR DESCRIPTION
This is in preparation for solving AstarVienna/ScopeSim#387

A resolving string is a string key ending in `"!"`. An instance of `NestedChainMap` will only continue to follow references if the key is a resolving key, otherwise it will return the value a the bang-string that is stored.